### PR TITLE
Does not checkout the `afterCommit` in the cloned repo

### DIFF
--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -28,6 +28,7 @@ router.post('/pages.json', function(req, res, next) {
 
     var opts = {
         ignoreCertErrors: 1,
+        checkoutBranch: config.deploy.deployBranch,
         remoteCallbacks: {
             credentials: function(url, userName) {
                 return NodeGit.Cred.sshKeyNew(

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -28,6 +28,7 @@ router.post('/pages.json', function(req, res, next) {
 
     var opts = {
         ignoreCertErrors: 1,
+        checkoutBranch: config.deploy.deployBranch, // remove this, once Checkout.tree() is implemented in nodegit
         remoteCallbacks: {
             credentials: function(url, userName) {
                 return NodeGit.Cred.sshKeyNew(
@@ -54,7 +55,8 @@ router.post('/pages.json', function(req, res, next) {
         function continueFn() {
             NodeGit.Clone.clone(url, repoPath, _.cloneDeep(opts))
             .then(function(repo) {
-                return NodeGit.Checkout.tree(repo, afterCommit, null);
+                //return NodeGit.Checkout.tree(repo, afterCommit, null); // not yet implemented in nodegit
+                return NodeGit.Checkout.head(repo,null);
             })
             .done(function() {
                 // Move from workingDir to pages dir

--- a/routes/webhooks.js
+++ b/routes/webhooks.js
@@ -28,7 +28,6 @@ router.post('/pages.json', function(req, res, next) {
 
     var opts = {
         ignoreCertErrors: 1,
-        checkoutBranch: config.deploy.deployBranch,
         remoteCallbacks: {
             credentials: function(url, userName) {
                 return NodeGit.Cred.sshKeyNew(
@@ -55,7 +54,7 @@ router.post('/pages.json', function(req, res, next) {
         function continueFn() {
             NodeGit.Clone.clone(url, repoPath, _.cloneDeep(opts))
             .then(function(repo) {
-                return repo.getCommit(afterCommit);
+                return NodeGit.Checkout.tree(repo, afterCommit, null);
             })
             .done(function() {
                 // Move from workingDir to pages dir


### PR DESCRIPTION
Without this addition we are only seeing master checked out.
Are we doing it wrong or was that bug?
